### PR TITLE
Fix typos and grammar errors

### DIFF
--- a/content/blog/migrating-to-kf.md
+++ b/content/blog/migrating-to-kf.md
@@ -123,7 +123,7 @@ As the plans are **sorted in a predictable way** and **do not contain any secret
 
 After the plan has been analysed and adjusted as necessary, it can be passed to the `apply` command to create all the resources in the Kf cluster.
 
-After checking the references in the plan have not changed since it was created, secrets and application bits are pulled from Cloud Foundry and the migrations is applied.
+After checking the references in the plan have not changed since it was created, secrets and application bits are pulled from Cloud Foundry and the migration is applied.
 
 The tool **pushes apps exactly as a human would** using the `kf` CLI before checking that they are healthy and are running with the correct buildpack and command.
 
@@ -140,7 +140,7 @@ A platform team can use the `plan` command to see which platform features may be
 By using scoped plans, individual teams can take ownership of the migration of an app or space themselves. By running `plan` and `apply` as issues are fixed, a team can **understand when an app is ready to be fully migrated** and when apps are ready for their CI pipelines to push to the new Kf cluster.
 
 ### Migrating orphaned apps
-By pulling the application source code package directly from Cloud Foundry and builds it in the same way, the migration tool allows for even **orphaned applications to be migrated to a new runtime** even without extensive knowledge of the application or a dedicated CI pipeline.
+By pulling the application source code package directly from Cloud Foundry and building it in the same way, the migration tool allows for even **orphaned applications to be migrated to a new runtime** even without extensive knowledge of the application or a dedicated CI pipeline.
 
 ## What else is left to do?
 After running `plan` and `apply`, you'll be left in a state of running applications in both Cloud Foundry and in Kf.
@@ -154,4 +154,4 @@ The next steps will involve working out how to start retiring your Cloud Foundry
 
 These are the questions where the answer will vary between users, so it can help to have partners on-hand to assist with the migration.
 
-> If you are thinking of migrating from Cloud Foundry to Kf, EngineerBetter can help you plan and execute through the entire lifecycle of a migration. As Cloud Foundry experts, Google Cloud partners and Kubernetes Certified Service providers we have the experience to ensure your migration has best possible outcomes.
+> If you are thinking of migrating from Cloud Foundry to Kf, EngineerBetter can help you plan and execute through the entire lifecycle of a migration. As Cloud Foundry experts, Google Cloud partners and Kubernetes Certified Service providers we have the experience to ensure your migration has the best possible outcomes.

--- a/content/blog/migrating-to-kf.md
+++ b/content/blog/migrating-to-kf.md
@@ -109,12 +109,12 @@ spaces:
 ```
 
 Notable parts of the plan YAML include:
-* Resources are **grouped by Kf `Space`** - an object that merges the Cloud Foundry concepts of organizations and spaces together and becomes a `Namespace` in Kubernetes
-* All resources (such as the `customers.my-enterprise.com` route) are included, even if they are not currently bound to any applications
-* Resource **names are transformed** for compatibility with Kf in the `new_name` fields which can be edited to tweak preferred naming
+* Resources **grouped by Kf `Space`** - an object that merges the Cloud Foundry concepts of organizations and spaces together and becomes a `Namespace` in Kubernetes
+* All resources (such as the `customers.my-enterprise.com` route), even if they are not currently bound to any applications
+* **Transformed resource names** for compatibility with Kf in the `new_name` fields which can be edited to tweak preferred naming
 * Annotated **`issues` on resources** such as the `apps.internal` domain indicate where features may not be fully compatible between Cloud Foundry and Kf
 * **Sensitive fields do not contain literal values**, for example binding `credentials` and application source code (`package`). Instead the plan contains links to Cloud Foundry API resources, which will be looked up at `apply` time.
-* Applications contain information such as `current_start_command` and `detected_buildpack_language` for later validating the success of the app migration
+* Information for applications such as `current_start_command` and `detected_buildpack_language` for later validating the success of the app migration
 * Kf compatible application manifests based on Cloud Foundry app details for comparing against or replacing existing app manifests
 
 As the plans are **sorted in a predictable way** and **do not contain any secrets** they are safe and easy to compare when committed to source control providing an **ideal point of collaboration**.


### PR DESCRIPTION
The content is not invalidated by anything in the [kf 2.5 release](https://cloud.google.com/migrate/kf/docs/2.5/resources/release-notes?hl=el).

New features that *might* be worth a mention:

1. Support for NFS mounts
2. Migrate to Anthos clusters
3. "Automated assessment and migration of your existing CF foundation." - but isn't this the whole point of kf? It's in the 2.5 release notes however. I'll scour the docs some more to see if anything is revealed about what this means.
4. [Task scheduling with cron syntax](https://cloud.google.com/migrate/kf/docs/2.5/how-to/scheduling-tasks?hl=el).